### PR TITLE
Allow PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,10 @@
     }
   },
   "require": {
-    "php": "^5.5 || ^7.0",
+    "php": "^5.5 || ^7.0 || ^8.0",
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.5.0",
     "symfony/yaml": "^4.2",
     "donatj/mock-webserver": "^2.0",
     "overtrue/phplint": "^1.1",


### PR DESCRIPTION
Hi there,

We're looking to use this package in a PHP 8 codebase. This PR bumps the composer PHP requirement to ^8.0 so it can be installed without problems.

Our testing shows no issues running the code under PHP 8. The only issue was `phpunit/phpunit` requiring `php: ^7.1`. Since phpunit is not used in the package I have removed the dependency entirely. If this dependency is somehow required please let me know what version would be acceptable. Additionally, PHPCompatibility shows no issues:

```
$ composer global require phpcompatibility/php-compatibility
$ ./bin/phpcs -p ./src --standard=~/.config/composer/vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.0

............................................................ 60 / 88 (68%)
............................                                 88 / 88 (100%)


Time: 937ms; Memory: 12MB
```