### PR TITLE
Throw an exception instead of an empty list return

### DIFF
--- a/src/Common/AuthenticatedHttpClient.php
+++ b/src/Common/AuthenticatedHttpClient.php
@@ -87,7 +87,7 @@ class AuthenticatedHttpClient
                 );
                 $response = $this->basicHttpClient->sendRequest($httpMethod, $resourceName, $query, $headers, $body);
             } catch (AuthenticateException $exception) {
-                $response = [];
+                throw new DpdException('Error response from DPD. '.$exception->getMessage(), $exception->getCode(), $exception);
             }
 
         }


### PR DESCRIPTION
https://github.com/dpdconnect/php-sdk/blob/master/src/Common/ResourceClient.php#L87

uses list($status, $response). When an error is returned from dpd api, the entire shipping backend crashes, as an array index of 0 does not exist on an empty array.

By transforming the exception to a DpdException it gets caught by https://github.com/dpdconnect/php-sdk/blob/12cabc0e204c56e5e9a7ff1fdde4492810cce6a2/src/Resources/Product.php#L34 and gets handled properly by returning a cached instance.

And the magento2 shipping configuration page works.