### PR TITLE
Fixed exception handling in product resource

### DIFF
--- a/src/Resources/Product.php
+++ b/src/Resources/Product.php
@@ -35,7 +35,7 @@ class Product extends BaseResource
             } else {
                 return [];
             }
-        } catch (DpdException $e) {
+        } catch (DpdException|\Exception $e) {
             $result = $this->cacheWrapper->getCachedList($query, true); //a year
 
             // So we had a failure save cache now for an hour


### PR DESCRIPTION
Made sure that a general exception is also allowed in the product resource. This to ensure the edit page doesn't display a blank screen when the client isn't available