### PR TITLE
Fixed Undefined array key "token"

### DIFF
--- a/src/Common/AuthenticatedHttpClient.php
+++ b/src/Common/AuthenticatedHttpClient.php
@@ -72,6 +72,10 @@ class AuthenticatedHttpClient
                     $this->authentication->getPassword()
                 );
 
+                if (($token['token'] ?? null) === null) {
+                    throw new \AuthenticateException('Could not get token by username and password.');
+                }
+
                 $this->authentication
                     ->setJwtToken($token['token']);
                 if (is_callable($this->authentication->tokenUpdateCallback)) {


### PR DESCRIPTION
When incorrect credentials are used `authenticateByPassword` returns an empty array instead of an exception or an empty token.

When you try to get the token from this empty array you'd get 
```
Warning: Undefined array key "token" in vendor/dpdconnect/php-sdk/src/Common/AuthenticatedHttpClient.php on line 76 
```

This PR throws the authenticationException so pages are not broken by missing or incorrect credentials